### PR TITLE
Update event-loop.js

### DIFF
--- a/src/main/resources/js/event-loop.js
+++ b/src/main/resources/js/event-loop.js
@@ -104,7 +104,7 @@
    * @param {Object} task timeout handle
    */
   function clearTimeout(task) {
-    if (task.cancel()) {
+    if (task && task.cancel()) {
       phaser.arriveAndDeregister();
     }
   }
@@ -142,7 +142,7 @@
    * @param {Object} interval handle
    */
   function clearInterval(task) {
-    if (task.cancel()) {
+    if (task && task.cancel()) {
       phaser.arriveAndDeregister();
     }
   }


### PR DESCRIPTION
I try to use nashorn-async to enable promise-7.0.4.min.js for running pdf-lib.js in nashorn. It is almost successful. Than you for your nashorn-async. And I found an error because of calling clearTimeout before setTimeout in promise-7.0.4.min.js. And it is no error in browses. You can try the next code in browsers.
```
var a; clearTimeout(a);
```
So I think it may be good to add a checking in clearTimeout and clearInterval. 
```
 if (task && task.cancel()) {
   phaser.arriveAndDeregister();
}
```